### PR TITLE
没有query的时候应该直接return

### DIFF
--- a/src/jquery.atwho.coffee
+++ b/src/jquery.atwho.coffee
@@ -154,7 +154,7 @@
     #
     # @return [Array] 排序后的数据列表
     sorter: (query, items, search_key) ->
-      items if !query
+      return items if !query
       results = []
 
       for item in items


### PR DESCRIPTION
我在Safari上面，运行正常。chrome上只输入@，结果是排过序的。

看着应该是少了个return，不知道Safari为什么是ok的
