### PR TITLE
query参数类型问题

### DIFF
--- a/src/jquery.atwho.coffee
+++ b/src/jquery.atwho.coffee
@@ -163,7 +163,7 @@
       if data and data.length > 0
         callback(data)
       else if (remote_filter = @context.callbacks('remote_filter'))
-        remote_filter.call(@context, query.text, callback)
+        remote_filter.call(@context, query, callback)
       else
         return no
       yes


### PR DESCRIPTION
使用中发现这个query变量是一个字符串，而不是一个query对象？
