### PR TITLE
Update bower.json to depend on jquery not jQuery

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,7 +10,7 @@
     "spec"
   ],
   "dependencies": {
-    "jQuery": ">=1.7.0",
+    "jquery": ">=1.7.0",
     "Caret.js": ">= 0.0.9"
   },
   "devDependencies": {


### PR DESCRIPTION
It appears Bower will happily resolve _both_ jQuery and jquery:
in projects that specify both At.js and other dependencies relying on
jQuery, Bower will attempt to install jQuery twice, possibly with
differing versions.

In the case of a case insensitive filesystem (Windows and Mac, by
default), the jQuery components directory will be overwritten/merged.
See: https://github.com/bower/bower/issues/1150

https://www.openproject.org/work_packages/7310
