### PR TITLE
Prevent JS error when result contain numeric value

### DIFF
--- a/dist/js/jquery.atwho.js
+++ b/dist/js/jquery.atwho.js
@@ -1,4 +1,4 @@
-/*! jquery.atwho - v0.5.0 - 2014-08-16
+/*! jquery.atwho - v0.5.0 - 2014-09-10
 * Copyright (c) 2014 chord.luo <chord.luo@gmail.com>; 
 * homepage: http://ichord.github.com/At.js 
 * Licensed MIT
@@ -692,7 +692,7 @@ DEFAULT_CALLBACKS = {
     _results = [];
     for (_i = 0, _len = data.length; _i < _len; _i++) {
       item = data[_i];
-      if (~item[search_key].toLowerCase().indexOf(query.toLowerCase())) {
+      if (~new String(item[search_key]).toLowerCase().indexOf(query.toLowerCase())) {
         _results.push(item);
       }
     }
@@ -700,17 +700,21 @@ DEFAULT_CALLBACKS = {
   },
   remote_filter: null,
   sorter: function(query, items, search_key) {
-    var item, _i, _len, _results;
+    var e, item, _i, _j, _len, _len1, _results;
     if (!query) {
       return items;
     }
     _results = [];
     for (_i = 0, _len = items.length; _i < _len; _i++) {
       item = items[_i];
-      item.atwho_order = item[search_key].toLowerCase().indexOf(query.toLowerCase());
+      item.atwho_order = new String(item[search_key]).toLowerCase().indexOf(query.toLowerCase());
       if (item.atwho_order > -1) {
         _results.push(item);
       }
+    }
+    for (_j = 0, _len1 = _results.length; _j < _len1; _j++) {
+      e = _results[_j];
+      console.log(e.name);
     }
     return _results.sort(function(a, b) {
       return a.atwho_order - b.atwho_order;

--- a/spec/javascripts/default_callbacks.spec.coffee
+++ b/spec/javascripts/default_callbacks.spec.coffee
@@ -31,6 +31,11 @@ describe "default callbacks", ->
     names = callbacks.filter.call(app, "jo", names, "name")
     expect(names).toContain name: "Joshua"
 
+  it "can filter numeric data", ->
+    numerics = callbacks.before_save.call(app, fixtures["numerics"])
+    numerics = callbacks.filter.call(app, "1", numerics, "name")
+    expect(numerics).toContain name: 10
+
   it "request data from remote by ajax if set remote_filter", ->
     remote_call = jasmine.createSpy("remote_call")
     $inputor.atwho
@@ -46,6 +51,11 @@ describe "default callbacks", ->
     names = callbacks.before_save.call(app, fixtures["names"])
     names = callbacks.sorter.call(app, "e", names, "name")
     expect(names[0].name).toBe 'Ethan'
+
+  it "can sort numeric data", ->
+    numerics = callbacks.before_save.call(app, fixtures["numerics"])
+    numerics = callbacks.sorter.call(app, "1", numerics, "name")
+    expect(numerics[0].name).toBe 13
 
   it "don't sort the data without a query", ->
     names = callbacks.before_save.call(app, fixtures["names"])

--- a/spec/javascripts/fixtures/json/data.json
+++ b/spec/javascripts/fixtures/json/data.json
@@ -15,5 +15,8 @@
   "sunrise", "sunrise_over_mountains", "surfer", "sushi", "suspect",
   "sweat", "sweat_drops", "swimmer", "syringe", "tada", "tangerine",
   "taurus", "taxi", "tea", "telephone", "tennis", "tent", "thumbsdown", "+1","-1"
+  ],
+  "numerics": [
+  6, 7, 13, 5, 4, 9, 1, 15, 14, 3, 8, 12, 2, 11, 10
   ]
 }

--- a/src/default.coffee
+++ b/src/default.coffee
@@ -58,7 +58,7 @@ DEFAULT_CALLBACKS =
     # !!null #=> false; !!undefined #=> false; !!'' #=> false;
     _results = []
     for item in data
-      _results.push item if ~item[search_key].toLowerCase().indexOf query.toLowerCase()
+      _results.push item if ~new String(item[search_key]).toLowerCase().indexOf query.toLowerCase()
     _results
 
   # If a function is given, At.js will invoke it if local filter can not find any data
@@ -84,7 +84,7 @@ DEFAULT_CALLBACKS =
 
     _results = []
     for item in items
-      item.atwho_order = item[search_key].toLowerCase().indexOf query.toLowerCase()
+      item.atwho_order = new String(item[search_key]).toLowerCase().indexOf query.toLowerCase()
       _results.push item if item.atwho_order > -1
 
     _results.sort (a,b) -> a.atwho_order - b.atwho_order


### PR DESCRIPTION
There is an error when using numerics data with At.js.

Configuration sample:

``` javascript
$('.atwho-inputor').atwho({
  at: "@",
  data: [1, 2, 3],
});
```

This PR is to correct that.
