### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "jquery.atwho",
+  "name": "at.js",
   "author": {
     "name": "chord.luo",
     "email": "chord.luo@gmail.com"
@@ -27,5 +27,17 @@
     "grunt-contrib-copy": "~0.5.0",
     "grunt-contrib-concat": "~0.3.0",
     "grunt-contrib-cssmin": "~0.9.0"
+  },
+  "spm": {
+    "main": "dist/js/jquery.atwho.js",
+    "dependencies": {
+      "jquery": "1.7.2",
+      "caret.js": "0.2.0"
+    },
+    "ignore": [
+      "examples",
+      "spec",
+      "src"
+    ]
   }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/at.js

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of at.js in spmjs, I can add it for your account after signing in http://spmjs.io.
