### PR TITLE
Fixes error with selecting always first item on the list on iOS WebView ...

### DIFF
--- a/dist/js/jquery.atwho.js
+++ b/dist/js/jquery.atwho.js
@@ -549,6 +549,9 @@ View = (function() {
     return $menu.on('mouseenter.atwho-view', 'li', function(e) {
       $menu.find('.cur').removeClass('cur');
       return $(e.currentTarget).addClass('cur');
+    }).on('click', 'li', function(e) {
+      $menu.find('.cur').removeClass('cur');
+      return $(e.currentTarget).addClass('cur');
     }).on('click', (function(_this) {
       return function(e) {
         _this.choose(e);
@@ -863,7 +866,6 @@ $.fn.atwho["default"] = {
   display_timeout: 300,
   delay: null
 };
-
 
 
 }));

--- a/src/view.coffee
+++ b/src/view.coffee
@@ -22,6 +22,9 @@ class View
     $menu.on 'mouseenter.atwho-view','li', (e) ->
       $menu.find('.cur').removeClass 'cur'
       $(e.currentTarget).addClass 'cur'
+    .on 'click','li', (e) ->
+      $menu.find('.cur').removeClass 'cur'
+      $(e.currentTarget).addClass 'cur'
     .on 'click', (e) =>
       this.choose(e)
       e.preventDefault()


### PR DESCRIPTION
...when using https://github.com/ftlabs/fastclick

I tested both for UiWebView and Safari on iOS 7.1.2, at.js version 0.5.1

Problem does not show up on Android 4.4.4 when using exact same code in Chrome.

Problem disappears when we stop using https://github.com/ftlabs/fastclick

It was causing error when using 0.4.1 version. It indicated index out of range, but varied among systems in exact message.

Sorry for lack of tests, but didn't know how to write them. We'd like to simulate popup opening and selection of ie. second item with artificial click event, no mouseenter event before that.
