### PR TITLE
add parameter to allow for a spacebar in the middle of a search so that ...

### DIFF
--- a/dist/js/jquery.atwho.js
+++ b/dist/js/jquery.atwho.js
@@ -873,15 +873,16 @@ DEFAULT_CALLBACKS = {
   beforeSave: function(data) {
     return Controller.arrayToDefaultHash(data);
   },
-  matcher: function(flag, subtext, should_startWithSpace) {
-    var match, regexp, _a, _y;
+  matcher: function(flag, subtext, should_startWithSpace, acceptSpaceBar) {
+    var match, regexp, space, _a, _y;
     flag = flag.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&");
     if (should_startWithSpace) {
       flag = '(?:^|\\s)' + flag;
     }
     _a = decodeURI("%C3%80");
     _y = decodeURI("%C3%BF");
-    regexp = new RegExp("" + flag + "([A-Za-z" + _a + "-" + _y + "0-9_\.\+\-]*)$|" + flag + "([^\\x00-\\xff]*)$", 'gi');
+    space = acceptSpaceBar ? "\ " : "";
+    regexp = new RegExp("" + flag + "([A-Za-z" + _a + "-" + _y + "0-9_" + space + "\.\+\-]*)$|" + flag + "([^\\x00-\\xff]*)$", 'gi');
     match = regexp.exec(subtext);
     if (match) {
       return match[2] || match[1];

--- a/spec/javascripts/default_callbacks.spec.coffee
+++ b/spec/javascripts/default_callbacks.spec.coffee
@@ -29,6 +29,24 @@ describe "default callbacks", ->
     query = callbacks.matcher.call(app, "@", text)
     expect(query).toBe("Jobs")
 
+  it "should not match a space following @ if acceptSpaceBar flag omitted", ->
+    $inputor = $("#inputor").atwho at: "@", data: fixtures["names"]
+    text = $.trim $inputor.text()
+    query = callbacks.matcher.call(app, "@", text)
+    expect(query).toBe("Jobs")
+
+  it "should not match a space following @ if acceptSpaceBar flag false", ->
+    $inputor = $("#inputor").atwho at: "@", data: fixtures["names"], acceptSpaceBar: false
+    text = $.trim $inputor.text()
+    query = callbacks.matcher.call(app, "@", text, false, false)
+    expect(query).toBe("Jobs")
+
+  it "should match a space following @ if acceptSpaceBar flag set to true", ->
+    $inputor = $("#inputor4").atwho at: "@", data: fixtures["names"], acceptSpaceBar: true
+    text = $.trim $inputor.text()
+    query = callbacks.matcher.call(app, "@", text, false, true)
+    expect(query).toBe("Jobs Blobs")
+
   it "should match the key word fllowing @ with specials chars", ->
     $inputor = $("#special-chars").atwho at: "@", data: fixtures["names"]
     text = $.trim $inputor.text()

--- a/spec/javascripts/fixtures/inputors.html
+++ b/spec/javascripts/fixtures/inputors.html
@@ -11,6 +11,10 @@
   Stay Foolish, Stay Hungry.s@Jobs
 </textarea>
 
+<textarea id="inputor4" name="at" rows="8" cols="40">
+  Stay Foolish, Stay Hungry. @Jobs Blobs
+</textarea>
+
 <div id="editable" contentEditable="true">
 Stay Foolish, Stay Hungry.  @J sss
 shfsdfssfasf  sjfsl

--- a/src/default.coffee
+++ b/src/default.coffee
@@ -39,18 +39,22 @@ DEFAULT_CALLBACKS =
   #
   # @param flag [String] current `flag` ("@", etc)
   # @param subtext [String] Text from start to current caret position.
+  # @param should_startWithSpace [boolean] accept white space as beginning of match.
+  # @param acceptSpaceBar [boolean] accept a space bar in the center of match,
+  #                                 so you can match a first and last name, for ex.
   #
   # @return [String | null] Matched result.
-  matcher: (flag, subtext, should_startWithSpace) ->
+  matcher: (flag, subtext, should_startWithSpace, acceptSpaceBar) ->
     # escape RegExp
     flag = flag.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, "\\$&")
     flag = '(?:^|\\s)' + flag if should_startWithSpace
-    
+
     # À
     _a = decodeURI("%C3%80")
     # ÿ
     _y = decodeURI("%C3%BF")
-    regexp = new RegExp "#{flag}([A-Za-z#{_a}-#{_y}0-9_\.\+\-]*)$|#{flag}([^\\x00-\\xff]*)$",'gi'
+    space = if acceptSpaceBar then "\ " else ""
+    regexp = new RegExp "#{flag}([A-Za-z#{_a}-#{_y}0-9_#{space}\.\+\-]*)$|#{flag}([^\\x00-\\xff]*)$",'gi'
     match = regexp.exec subtext
     if match then match[2] || match[1] else null
 


### PR DESCRIPTION
...you can match a first + space + last name, for example. This modification was necessary for our use as we have a large-ish database of names we are matching against (3500 + growing) and therefore several people with similar names. This functionality also more closely matches the @mention functionality of Facebook & Twitter.