### PR TITLE
Adds option to omit lookUp on click

### DIFF
--- a/src/api.coffee
+++ b/src/api.coffee
@@ -51,5 +51,6 @@ $.fn.atwho.default =
   editableAtwhoQueryAttrs: {}
   scrollDuration: 150
   suspendOnComposing: true
+  lookUpOnClick: true
 
 $.fn.atwho.debug = false

--- a/src/controller.coffee
+++ b/src/controller.coffee
@@ -91,6 +91,7 @@ class Controller
 
   # Searching!
   lookUp: (e) ->
+    return if e == 'click' && !this.setting.lookUpOnClick
     return if @getOpt('suspendOnComposing') and @app.isComposing 
     query = @catchQuery e
     if not query


### PR DESCRIPTION
Specific to my use case. I need the atwho element to not do a lookup once is matched and inserted into (my case) a content editable. Reason being that I need other listeners actions to happen without the atwho view being rendered. 