### PR TITLE
the jQuery npm package is now called jquery

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "test": "grunt test --verbose"
   },
   "dependencies": {
-    "jQuery": "~1.7.0"
+    "jquery": "~1.7.0"
   },
   "devDependencies": {
     "grunt": "^0.4.5",


### PR DESCRIPTION
The jQuery npm package is called jquery (lowercase).

This is the official package: https://www.npmjs.com/package/jquery

The one called jQuery is not the official package: https://www.npmjs.com/package/jQuery