### PR TITLE
Iframe scope and acceptSpaceBar option fixes.

### DIFF
--- a/dist/js/jquery.atwho.js
+++ b/dist/js/jquery.atwho.js
@@ -148,23 +148,26 @@ App = (function() {
     if (asRoot == null) {
       asRoot = false;
     }
-    if (iframe) {
-      this.window = iframe.contentWindow;
-      this.document = iframe.contentDocument || this.window.document;
-      this.iframe = iframe;
-    } else {
-      this.document = this.$inputor[0].ownerDocument;
-      this.window = this.document.defaultView || this.document.parentWindow;
-      try {
-        this.iframe = this.window.frameElement;
-      } catch (error1) {
-        error = error1;
-        this.iframe = null;
-        if ($.fn.atwho.debug) {
-          throw new Error("iframe auto-discovery is failed.\nPlease use `setIframe` to set the target iframe manually.\n" + error);
-        }
+    if (iframe && iframe != true) {
+        this.window = iframe.contentWindow;
+        this.document = iframe.contentDocument || this.window.document;
+        this.iframe = iframe;
+      } else if (iframe == true) {
+      	 this.document = this.$inputor[0].ownerDocument;
+           this.window = this.document.defaultView || this.document.parentWindow;
+           this.iframe = null;
+              	
+      } else {
+      	this.document = this.$inputor[0].ownerDocument;
+          this.window = this.document.defaultView || this.document.parentWindow;
+          try {
+              this.iframe = this.window.frameElement;
+            } catch (_error) {
+              error = _error;
+              this.iframe = null;
+              throw new Error("iframe auto-discovery is failed.\nPlease use `serIframe` to set the target iframe manually.");
+            }
       }
-    }
     return this.createContainer((this.iframeAsRoot = asRoot) ? this.document : document);
   };
 
@@ -572,7 +575,7 @@ TextareaController = (function(superClass) {
       iframe: this.app.iframe
     });
     subtext = content.slice(0, caretPos);
-    query = this.callbacks("matcher").call(this, this.at, subtext, this.getOpt('startWithSpace'));
+    query = this.callbacks("matcher").call(this, this.at, subtext, this.getOpt('startWithSpace'), this.getOpt('acceptSpaceBar'));
     isString = typeof query === 'string';
     if (isString && query.length < this.getOpt('minLen', 0)) {
       return;
@@ -762,7 +765,7 @@ EditableController = (function(superClass) {
     }
     _range = range.cloneRange();
     _range.setStart(range.startContainer, 0);
-    matched = this.callbacks("matcher").call(this, this.at, _range.toString(), this.getOpt('startWithSpace'));
+    matched = this.callbacks("matcher").call(this, this.at, _range.toString(), this.getOpt('startWithSpace'), this.getOpt('acceptSpaceBar'));
     isString = typeof matched === 'string';
     if ($query.length === 0 && isString && (index = range.startOffset - this.at.length - matched.length) >= 0) {
       range.setStart(range.startContainer, index);
@@ -1174,6 +1177,7 @@ $.fn.atwho["default"] = {
   searchKey: "name",
   suffix: void 0,
   hideWithoutSuffix: false,
+  acceptSpaceBar : true,
   startWithSpace: true,
   highlightFirst: true,
   limit: 5,

--- a/dist/js/jquery.atwho.js
+++ b/dist/js/jquery.atwho.js
@@ -149,24 +149,25 @@ App = (function() {
       asRoot = false;
     }
     if (iframe && iframe != true) {
-        this.window = iframe.contentWindow;
-        this.document = iframe.contentDocument || this.window.document;
-        this.iframe = iframe;
-      } else if (iframe == true) {
-      	 this.document = this.$inputor[0].ownerDocument;
-           this.window = this.document.defaultView || this.document.parentWindow;
-           this.iframe = null;
-              	
-      } else {
+      this.window = iframe.contentWindow;
+      this.document = iframe.contentDocument || this.window.document;
+      this.iframe = iframe;
+    } else if (iframe == true) {
+      this.document = this.$inputor[0].ownerDocument;
+      this.window = this.document.defaultView || this.document.parentWindow;
+      this.iframe = null;              	
+    } else {
       	this.document = this.$inputor[0].ownerDocument;
-          this.window = this.document.defaultView || this.document.parentWindow;
-          try {
-              this.iframe = this.window.frameElement;
-            } catch (_error) {
-              error = _error;
-              this.iframe = null;
-              throw new Error("iframe auto-discovery is failed.\nPlease use `serIframe` to set the target iframe manually.");
+        this.window = this.document.defaultView || this.document.parentWindow;
+        try {
+        	this.iframe = this.window.frameElement;
+        } catch (error1) {
+            error = error1;
+            this.iframe = null;
+            if ($.fn.atwho.debug){
+            	throw new Error("iframe auto-discovery is failed.\nPlease use `serIframe` to set the target iframe manually.");
             }
+        }
       }
     return this.createContainer((this.iframeAsRoot = asRoot) ? this.document : document);
   };
@@ -1196,3 +1197,4 @@ $.fn.atwho["default"] = {
 $.fn.atwho.debug = false;
 
 }));
+


### PR DESCRIPTION
Fixed an issue where if atWho is used on a site which is loaded into an iframe, the window scope does not work causing atWho to crash.

Added support for the acceptSpaceBar option, for it to be passed through the matcher.