### PR TITLE
fix chinese character not support problem

### DIFF
--- a/dist/js/jquery.atwho.js
+++ b/dist/js/jquery.atwho.js
@@ -52,7 +52,7 @@ DEFAULT_CALLBACKS = {
     _a = decodeURI("%C3%80");
     _y = decodeURI("%C3%BF");
     space = acceptSpaceBar ? "\ " : "";
-    regexp = new RegExp(flag + "([A-Za-z" + _a + "-" + _y + "0-9_" + space + "\'\.\+\-]*)$|" + flag + "([^\\x00-\\xff]*)$", 'gi');
+    regexp = new RegExp(flag + "([A-Za-z" + _a + "-" + _y + "0-9\u4e00-\u9fa5_" + space + "\'\.\+\-]*)$|" + flag + "([^\\x00-\\xff]*)$", 'gi');
     match = regexp.exec(subtext);
     if (match) {
       return match[2] || match[1];


### PR DESCRIPTION
description：
when i input chinese character after English character , can not match! for example:
1. if i input “#12”, can match to “12中国”
2. if i input “#12中”, can not match to “12中国”
3. if i input “#中”, can match to “12中国”
For more details, please see my blog:
[修复ichord/At.js插件的中文不支持问题](http://kexun.github.io/2016/02/18/%E4%BF%AE%E5%A4%8Dichord-At-js%E6%8F%92%E4%BB%B6%E7%9A%84%E4%B8%AD%E6%96%87%E4%B8%8D%E6%94%AF%E6%8C%81%E9%97%AE%E9%A2%98/#more)