### PR TITLE
Add timeout to compositionend dispatch call

### DIFF
--- a/src/app.coffee
+++ b/src/app.coffee
@@ -76,6 +76,7 @@ class App
         null
       .on 'compositionend', (e) =>
         @isComposing = false
+        setTimeout((e) => @dispatch(e))
         null
       .on 'keyup.atwhoInner', (e) =>
         this.onKeyup(e)


### PR DESCRIPTION
Fixes composition callback for languages like Japanese and Korean; details here: https://github.com/ichord/At.js/pull/384