### PR TITLE
View.visible performance fix

### DIFF
--- a/src/view.coffee
+++ b/src/view.coffee
@@ -44,7 +44,7 @@ class View
   #
   # @return [Boolean]
   visible: ->
-    @$el.is(":visible")
+    @$el[0].style.display == "block"
 
   highlighted: ->
     @$el.find(".cur").length > 0

--- a/src/view.coffee
+++ b/src/view.coffee
@@ -44,7 +44,7 @@ class View
   #
   # @return [Boolean]
   visible: ->
-    @this.$el.style.display == "block"
+    @$el.is(":visible")
 
   highlighted: ->
     @$el.find(".cur").length > 0

--- a/src/view.coffee
+++ b/src/view.coffee
@@ -44,7 +44,7 @@ class View
   #
   # @return [Boolean]
   visible: ->
-    @$el.is(":visible")
+    @this.$el.style.display == "block"
 
   highlighted: ->
     @$el.find(".cur").length > 0

--- a/src/view.coffee
+++ b/src/view.coffee
@@ -44,7 +44,7 @@ class View
   #
   # @return [Boolean]
   visible: ->
-    @$el[0].style.display == "block"
+    $.expr.filters.visible(@$el[0])
 
   highlighted: ->
     @$el.find(".cur").length > 0


### PR DESCRIPTION

### Replaced use of jQuery $el.is("visible") with $.expr.filters.visible(this.$el[0]);
The time $el.is(":visible") takes increases as the number of elements visible on the page increases and even with a reasonable amount of visible elements for a web application this function takes around 11ms on nearly every key press. This occurs because $el.is(":visible") searches for $el in the array of elements that match :visible which is normally hundreds of elements (in my case, thousands).

$.expr.filters.visible(e) simply runs the function that jQuery uses to decide whether a single element matches the :visible criteria. That function checks a few things like css display and visibility and offsetWidth/Height on the element and all of it's parents recursively. And since this function is checking the visibility of an atwho-view, it'd usually only have two parents to check and almost always be faster than searching the array of all :visible.

Below are some tests I ran. We actually have pages that have several thousand visible elements so this kind of performance isn't usable for our project. Times are taken from the Chrome and IE dev tools Profiler.

### Before Change :
Chrome 51 with 5432 :visible 95-110ms
Chrome 51 with 1864 :visible 32-40ms
Chrome 51 with 845 :visible ~20ms
Chrome 51 with 452 :visible ~11ms
IE 11 with 1873 :visible 75-90ms

### After change  :
Chrome 51 with 5432 :visible <1ms
Chrome with 1769 :visible <1ms 
IE with 1877 :visible 1ms 