### PR TITLE
Highlight strings with spaces

### DIFF
--- a/src/default.coffee
+++ b/src/default.coffee
@@ -126,7 +126,7 @@ DEFAULT_CALLBACKS =
   # @return [String] highlighted string.
   highlighter: (li, query) ->
     return li if not query
-    regexp = new RegExp(">\\s*(\\w*?)(" + query.replace("+","\\+") + ")(\\w*)\\s*<", 'ig')
+    regexp = new RegExp(">\\s*([^\<]*?)(" + query.replace("+","\\+") + ")([^\<]*)\\s*<", 'ig')
     li.replace regexp, (str, $1, $2, $3) -> '> '+$1+'<strong>' + $2 + '</strong>'+$3+' <'
 
   # What to do before inserting item's value into inputor.


### PR DESCRIPTION
At the moment, strings with spaces are not matched by the regex and thus not highlighted. \w matches any character but not spaces. Replacing it with a [^<], which matches anything except less-than brackets, works fine in my tests.

Feel free to test and merge eventually.