### PR TITLE
Correct package.json dependency manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "gulp-concat": "^2.6.0",
     "gulp-cssmin": "^0.1.7",
     "gulp-debug": "^2.1.2",
+    "gulp-header": "^1.7.1",
     "gulp-jasmine": "^2.2.1",
     "gulp-jasmine-phantom": "^2.0.1",
     "gulp-rename": "^1.2.2",

--- a/package.json
+++ b/package.json
@@ -18,13 +18,12 @@
   "scripts": {
     "test": "gulp test"
   },
-  "dependencies": {
-    "gulp-bump": "^1.0.0",
-    "gulp-header": "^1.7.1",
+  "peerDependencies": {
     "jquery": "^1.7.0"
   },
   "devDependencies": {
     "gulp": "^3.9.0",
+    "gulp-bump": "^1.0.0",
     "gulp-coffee": "^2.3.1",
     "gulp-concat": "^2.6.0",
     "gulp-cssmin": "^0.1.7",


### PR DESCRIPTION
This PR moves jQuery to a peer dependency and moves gulp plugins to devDependencies. By expressing jQuery as a peerDependency instead of a direct dependency, it makes At.js play nicer with other libraries which also depend on jQuery.
