### PR TITLE
Allow newer versions of jQuery as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "test": "gulp test"
   },
   "peerDependencies": {
-    "jquery": "^1.7.0"
+    "jquery": ">=1.7.0 <4.0.0"
   },
   "devDependencies": {
     "gulp": "^3.9.0",


### PR DESCRIPTION
The current peer dependency specification doesn't allow versions of jQuery in the 2.x or 3.x lines, both of which are (I believe) compatible with this plugin. This updates `package.json` to allow them.