### PR TITLE
trigger mouse selection on mousedown not click

### DIFF
--- a/src/view.coffee
+++ b/src/view.coffee
@@ -34,7 +34,7 @@ class View
       return if $cur.hasClass('cur')
       $menu.find('.cur').removeClass 'cur'
       $cur.addClass 'cur'
-    .on 'click.atwho-view', 'li', (e) =>
+    .on 'mousedown.atwho-view', 'li', (e) =>
       $menu.find('.cur').removeClass 'cur'
       $(e.currentTarget).addClass 'cur'
       this.choose(e)


### PR DESCRIPTION
Not entirely sure why click works in the demo but not in my code. In my code the click would happen after the selection was switched to the dropdown so the range was wrong. Changing it to mousedown prevents the selection/range from leaving the input box.