### PR TITLE
Return early for undefined events

### DIFF
--- a/src/app.coffee
+++ b/src/app.coffee
@@ -106,6 +106,8 @@ class App
     @$el.remove()
 
   dispatch: (e) ->
+    if undefined == e
+      return
     c.lookUp(e) for _, c of @controllers
 
   onKeyup: (e) ->


### PR DESCRIPTION
Reported here: https://github.com/ichord/At.js/issues/443

Keyboards in different languages were triggering undefined events, usually after a keypress and the symbol options were shown.

To replicate: Change keyboard to Chinese Simple, type something, the first event will be a keypress, then as the symbol keyboard shows a undefined event is sent to the dispatch method.
![keyboard](https://user-images.githubusercontent.com/1653699/35466786-edbc0e04-02bb-11e8-8e49-cc8577809151.gif)

This simple early return blocks those undefined events from filtering through.