### PR TITLE
Pass event object for error

### DIFF
--- a/src/app.coffee
+++ b/src/app.coffee
@@ -76,7 +76,7 @@ class App
         null
       .on 'compositionend', (e) =>
         @isComposing = false
-        setTimeout((e) => @dispatch(e))
+        setTimeout(((e) => @dispatch(e)).bind(this, e))
         null
       .on 'keyup.atwhoInner', (e) =>
         this.onKeyup(e)


### PR DESCRIPTION
Pass event object in setTimeout function.  It occurs a error. Because 'e' is undefined.

