### PR TITLE
Escape dot in highlighter regex

### DIFF
--- a/src/default.coffee
+++ b/src/default.coffee
@@ -124,7 +124,7 @@ DEFAULT_CALLBACKS =
   # @return [String] highlighted string.
   highlighter: (li, query) ->
     return li if not query
-    regexp = new RegExp(">\\s*([^\<]*?)(" + query.replace("+","\\+") + ")([^\<]*)\\s*<", 'ig')
+    regexp = new RegExp(">\\s*([^\<]*?)(" + query.replace("+","\\+").replace(".","\\.") + ")([^\<]*)\\s*<", 'ig')
     li.replace regexp, (str, $1, $2, $3) -> '> '+$1+'<strong>' + $2 + '</strong>'+$3+' <'
 
   # What to do before inserting item's value into inputor.


### PR DESCRIPTION
When `.` is the first character in a query, the regex incorrectly matches any character after a closing `>`, not the intended query text.